### PR TITLE
Adding the links of paper and codes of Wav-KAN:Wavelet Kolmogorov-Arnold Networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A curated list of awesome libraries, projects, tutorials, papers, and other reso
 - [Chebyshev Polynomial-Based Kolmogorov-Arnold Networks](https://arxiv.org/html/2405.07200v1) : The document discusses a novel neural network architecture called the Chebyshev Kolmogorov-Arnold Network (Chebyshev KAN) for approximating complex nonlinear functions. It combines the theoretical foundations of the Kolmogorov-Arnold Theorem with the powerful approximation capabilities of Chebyshev polynomials. The Chebyshev KAN layer approximates a target multivariate function by representing it as a weighted sum of Chebyshev polynomials, leveraging the Kolmogorov-Arnold Theorem's guarantee of the existence of a superposition of univariate functions to represent any continuous multivariate function. The paper provides a detailed mathematical explanation of the implementation, training, and optimization of the Chebyshev KAN layer, as well as experimental results demonstrating its effectiveness in approximating complex fractal-like functions.
 - [TKAN: Temporal Kolmogorov-Arnold Networks](https://arxiv.org/abs/2405.07344) ｜ [code](https://github.com/remigenet/tkan) ｜ ![Github stars](https://img.shields.io/github/stars/remigenet/tkan.svg)
 - [Kolmogorov-Arnold Networks (KANs) for Time Series Analysis](https://arxiv.org/pdf/2405.08790)
+-[Wav-KAN: Wavelet Kolmogorov-Arnold Networks](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4835325)
 
 ### Theorem
 
@@ -60,6 +61,7 @@ A curated list of awesome libraries, projects, tutorials, papers, and other reso
 - [Deep-KAN](https://github.com/Sid2690/Deep-KAN): Better implementation of Kolmogorov Arnold Network  | ![Github stars](https://img.shields.io/github/stars/Sid2690/Deep-KAN.svg)
 - [RBF-KAN](https://github.com/Sid2690/RBF-KAN): RBF-KAN is a PyTorch module that implements a Radial Basis Function Kolmogorov-Arnold Network  | ![Github stars](https://img.shields.io/github/stars/Sid2690/RBF-KAN.svg)
 - [KolmogorovArnold.jl](https://github.com/vpuri3/KolmogorovArnold.jl) : Very fast Julia implementation of KANs with RBF and RSWAF basis. Extra speedup is gained by writing custom gradients to share work between forward and backward pass. ｜ ![Github stars](https://img.shields.io/github/stars/vpuri3/KolmogorovArnold.jl)
+--[Wav-KAN](https://github.com/zavareh1/Wav-KAN): Wav-KAN: Wavelet Kolmogorov-Arnold Networks
 
 
 ### ConvKANs


### PR DESCRIPTION
Description of Changes/Additions:

Papers Section:

Added a link to the paper titled "[Wav-KAN: Wavelet Kolmogorov-Arnold Networks](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4835325)" to provide a detailed explanation of the Wav-KAN methodology and its applications.
Library Section:

Added a link to the GitHub repository for "[Wav-KAN](https://github.com/zavareh1/Wav-KAN)": This library implements the Wavelet Kolmogorov-Arnold Networks, allowing users to utilize the Wav-KAN framework for their projects. 

These additions aim to enhance the repository by providing valuable resources related to the Kolmogorov-Arnold Network, including both theoretical foundations and practical implementations