### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ A curated list of awesome libraries, projects, tutorials, papers, and other reso
 - [cuda-Wavelet-KAN](https://github.com/Da1sypetals/cuda-Wavelet-KAN) : CUDA implementation of Wavelet KAN.  | ![Github stars](https://img.shields.io/github/stars/Da1sypetals/cuda-Wavelet-KAN.svg)
 - [FlashKAN](https://github.com/dinesh110598/FlashKAN/): Grid size-independent computation of Kolmogorov Arnold networks | ![Github stars](https://img.shields.io/github/stars/dinesh110598/FlashKAN.svg)
 - [BSRBF_KAN](https://github.com/hoangthangta/BSRBF_KAN/): Combine B-Spline (BS) and Radial Basic Function (RBF) in Kolmogorov-Arnold Networks (KANs) | ![Github stars](https://img.shields.io/github/stars/hoangthangta/BSRBF_KAN.svg)
+- [TaylorKAN](https://github.com/Muyuzhierchengse/TaylorKAN/): Kolmogorov-Arnold Networks (KAN) using Taylor series instead of Fourier | ![Github stars](https://img.shields.io/github/stars/Muyuzhierchengse/TaylorKAN.svg)
 
 
 ### ConvKANs


### PR DESCRIPTION
About TaylorKAN
Our code is optimized and modified based on FourierKAN. After research and experiments, we found that the accuracy and number of parameters of FourierKAN are not good enough, and it does not reflect the advantages of KAN. According to the KA theorem, we use Taylor expansion to replace Fourier and propose the TaylorKAN model. We choose the MINIST data set, and the accuracy of TaylorKAN+CNN reaches 98.72%, which is close to CNN and much better than FourierKAN+CNN. The number of parameters is 307850, which is 37% of the number of CNN parameters 824458 and 18% of Fourier. The running time is similar to Fourier. TaylorKAN also has the best effect in fitting complex formulas.