### PR TITLE
Added a paper: FourierKAN outperforms MLP on Text Classification Head Fine-tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ A curated list of awesome libraries, projects, tutorials, papers, and other reso
 - [A Survey on Kolmogorov-Arnold Network](https://arxiv.org/abs/2411.06078)
 - [Low Tensor-Rank Adaptation of Kolmogorov--Arnold Networks](https://arxiv.org/abs/2502.06153)
 - [Kolmogorov-Arnold Fourier Networks](https://arxiv.org/abs/2502.06018)
+- [FourierKAN outperforms MLP on Text Classification Head Fine-tuning](https://arxiv.org/abs/2408.08803) | [code](https://github.com/abdalimran/FR-KAN-Text-Classification) | ![Github stars](https://img.shields.io/github/stars/abdalimran/FR-KAN-Text-Classification.svg)
 
 ### Theorem
 


### PR DESCRIPTION
The paper: **FourierKAN outperforms MLP on Text Classification Head Fine-tuning** uses a variant of KAN that relies on the Fourier functions. The authors replaced the MLP classification heads with these FourierKAN modules and outperformed MLPs in most standard text classification tasks.